### PR TITLE
Fix auto-translation when languages differ

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -566,14 +566,15 @@ app.post('/relay', async (req, res) => {
         // ─── ここで送信先サーバーの言語設定を Redis から取得 ───
         const destLang = await redis.hget(`lang:${ch.guildId}`, 'lang');
         const autoOn   = (await redis.hget(`lang:${ch.guildId}`, 'auto')) === 'true';
+        const srcLang  = await redis.hget(`lang:${p.guildId}`, 'lang');
 
         // デバッグ用ログ（Redis から取得できているか確認）
-        console.log(`→ Relay to ${channelId} (guild:${ch.guildId}): destLang=${destLang}, autoOn=${autoOn}`);
+        console.log(`→ Relay to ${channelId} (guild:${ch.guildId}): destLang=${destLang}, autoOn=${autoOn}, srcLang=${srcLang}`);
 
         let finalContent = p.content;
         let autoFlag = false;
-        // 「Auto-Translate ON」で言語設定があれば翻訳を試みる
-        if (autoOn && destLang) {
+        // 「Auto-Translate ON」で言語設定があり、送信元と異なる場合に翻訳
+        if (autoOn && destLang && destLang !== srcLang) {
           try {
             finalContent = await translate(p.content, destLang);
             autoFlag = true;

--- a/hub/hub.js
+++ b/hub/hub.js
@@ -69,7 +69,7 @@ app.post('/publish', async (req, res) => {
     // 翻訳設定取得
     const langInfo = await redis.hgetall(`lang:${guildId}`);
     const lang     = langInfo?.lang ?? null;
-    const shouldTranslate = lang && langInfo?.autoTranslate !== 'false';
+    const shouldTranslate = lang && langInfo?.auto !== 'false';
     const targetLang      = shouldTranslate ? lang : null;
 
     // ログ：Relay 宛先と targetLang


### PR DESCRIPTION
## Summary
- ensure hub checks `auto` flag when deciding destination language
- only translate in `/relay` when destination language differs from source

## Testing
- `npm test` in `hub` *(fails: no test specified)*
- `npm test` in `bot` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2f6fbcc8320bbbe06e537547735