### PR TITLE
Fix hub registration endpoint

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -153,7 +153,7 @@ async function handleSetup(interaction) {
 
     /* 3-6) Redis 登録＆HUB 連携 */
     await redis.sadd('global:channels', globalChat.id);
-    fetch(process.env.HUB_ENDPOINT + '/register', {
+    fetch(process.env.HUB_ENDPOINT + '/global/join', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ guildId: interaction.guild.id, channelId: globalChat.id })


### PR DESCRIPTION
## Summary
- register new channels with `/global/join` instead of non‑existent `/register`

## Testing
- `npm test` (fails: missing script)
- `npm test` in `hub` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6840dd535fc08320b0f974f6c3bf2b0a