### PR TITLE
Fix bot channel registration

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -152,8 +152,8 @@ async function handleSetup(interaction) {
     });
 
     /* 3-6) Redis 登録＆HUB 連携 */
-    await redis.sadd('global:channels', globalChat.id);
-    fetch(process.env.HUB_ENDPOINT + '/register', {
+    await redis.sadd('bot:channels', globalChat.id);
+    fetch(process.env.HUB_ENDPOINT + '/global/join', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ guildId: interaction.guild.id, channelId: globalChat.id })
@@ -388,7 +388,7 @@ client.on(Events.InteractionCreate, async (i) => {
 client.on(Events.MessageCreate, async (msg) => {
   // Bot 自身のメッセージや、Global Chat につながっていないチャンネルは無視
   if (msg.author.bot) return;
-  if (!(await redis.sismember('global:channels', msg.channelId))) return;
+  if (!(await redis.sismember('bot:channels', msg.channelId))) return;
 
   /* 1) メッセージ統計 */
   await redis.incrby(kMsg(msg.author.id), 1);
@@ -468,8 +468,8 @@ client.on(Events.MessageCreate, async (msg) => {
       reply: payload.replyExcerpt
     });
 
-    // Redis に登録されているすべての global:channels を巡回
-    const channelIds = await redis.smembers('global:channels');
+    // Redis に登録されているすべての bot:channels を巡回
+    const channelIds = await redis.smembers('bot:channels');
     for (const channelId of channelIds) {
       // 自分自身の投稿チャンネルには送り返さない
       if (channelId === msg.channelId) continue;
@@ -554,7 +554,7 @@ app.post('/relay', async (req, res) => {
   try {
     const p = req.body;
     // p: { globalId, guildId, channelId, userTag, userAvatar, originGuild, tz, content, replyExcerpt, files, targetLang, userId }
-    for (const channelId of await redis.smembers('global:channels')) {
+    for (const channelId of await redis.smembers('bot:channels')) {
       if (channelId === p.channelId) continue;
 
       const dupKey = `${p.globalId}:${channelId}`;


### PR DESCRIPTION
## Summary
- fix setup to register global chat channels in a `bot:channels` set and use `/global/join`
- update message handling and relay logic to read from the new set

## Testing
- `npm test` in `bot` *(fails: Missing script "test")*
- `npm test` in `hub` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd535fc08320b0f974f6c3bf2b0a