### PR TITLE
Add Node.js 18 requirement note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Global Chat
+
+This project includes a Discord bot and relay hub.
+
+## Node.js requirement
+
+The bot relies on the global `fetch` API, which is available in **Node.js 18** and newer. Use Node 18 or later to run the bot.
+
+If you must support older Node versions, install a `fetch` polyfill such as [`node-fetch`](https://www.npmjs.com/package/node-fetch) and import it before the bot code.

--- a/bot/index.js
+++ b/bot/index.js
@@ -7,6 +7,7 @@
  *  2. /relay 処理にデバッグ用ログを追加し、Redis から読まれる destLang・autoOnが正しく取得できているかを確認
  *  3. 条件を満たす場合にきちんと Google 翻訳を呼び出して、翻訳済みテキストを送信するように修正
  */
+// Requires Node.js 18 or later for global `fetch`. Install `node-fetch` or another polyfill if using an older Node.
 
 import 'dotenv/config';
 import {


### PR DESCRIPTION
## Summary
- add README documenting Node.js 18+ requirement for global `fetch`
- note polyfill for older Node versions
- document Node 18 requirement in bot code

## Testing
- `npm test` in `bot` *(fails: Missing script "test")*
- `npm test` in `hub` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684100aad50c83208abf8ff81b17442c