### PR TITLE
Centralize region-lang mapping

### DIFF
--- a/bot/commands/help.js
+++ b/bot/commands/help.js
@@ -5,6 +5,7 @@ import {
   StringSelectMenuBuilder,
   EmbedBuilder,
 } from 'discord.js';
+import { LANG_CHOICES } from '../constants.js';
 
 export const HELP_TEXTS = {
   // 日本語
@@ -2708,34 +2709,7 @@ export default {
 
   async execute(interaction) {
     // 言語選択用セレクトメニューを生成
-    const options = [
-      { label: '日本語',           value: 'ja',    emoji: '🇯🇵' },
-      { label: 'English (US)',    value: 'en',    emoji: '🇺🇸' },
-      { label: 'English (UK)',    value: 'en-GB', emoji: '🇬🇧' },
-      { label: '中文 (简体)',        value: 'zh',    emoji: '🇨🇳' },
-      { label: '中文 (繁體)',       value: 'zh-TW', emoji: '🇹🇼' },
-      { label: '한국어',          value: 'ko',    emoji: '🇰🇷' },
-      { label: 'Español (ES)',   value: 'es',    emoji: '🇪🇸' },
-      { label: 'Español (MX)',   value: 'es-MX', emoji: '🇲🇽' },
-      { label: 'Français',       value: 'fr',    emoji: '🇫🇷' },
-      { label: 'Deutsch',        value: 'de',    emoji: '🇩🇪' },
-      { label: 'Português (PT)', value: 'pt',    emoji: '🇵🇹' },
-      { label: 'Português (BR)', value: 'pt-BR', emoji: '🇧🇷' },
-      { label: 'Русский',         value: 'ru',    emoji: '🇷🇺' },
-      { label: 'Українська',      value: 'uk',    emoji: '🇺🇦' },
-      { label: 'Ελληνικά',        value: 'el',    emoji: '🇬🇷' },
-      { label: 'עִבְרִית',        value: 'he',    emoji: '🇮🇱' },
-      { label: 'اُردُو',          value: 'ur',    emoji: '🇵🇰' },
-      { label: 'Bahasa Melayu',   value: 'ms',    emoji: '🇲🇾' },
-      { label: 'Español (CO)',   value: 'es-CO', emoji: '🇨🇴' },
-      { label: 'فارسی',          value: 'fa',    emoji: '🇮🇷' },
-      { label: 'বাংলা',          value: 'bn',    emoji: '🇧🇩' },
-      { label: 'ไทย',           value: 'th',    emoji: '🇹🇭' },
-      { label: 'Tiếng Việt',     value: 'vi',    emoji: '🇻🇳' },
-      { label: 'हिन्दी',         value: 'hi',    emoji: '🇮🇳' },
-      { label: 'Bahasa Indonesia',value: 'id',   emoji: '🇮🇩' },
-      { label: 'العربية',        value: 'ar',    emoji: '🇸🇦' },
-    ];
+    const options = LANG_CHOICES;
 
     const selectMenu = new ActionRowBuilder()
       .addComponents(

--- a/bot/constants.js
+++ b/bot/constants.js
@@ -64,3 +64,24 @@ export const FLAG_TO_LANG = {
   '🇮🇩': 'id',
   '🇸🇦': 'ar'
 };
+
+/**
+ * 地域 → 言語コード一覧のマッピング
+ */
+export const REGIONS = [
+  { label: 'Asia',                   value: 'asia',          emoji: '🌏' },
+  { label: 'Europe',                 value: 'europe',        emoji: '🌍' },
+  { label: 'North America',          value: 'north_america', emoji: '🌎' },
+  { label: 'South America',          value: 'south_america', emoji: '🌎' },
+  { label: 'Middle East & Africa',   value: 'mea',           emoji: '🌍' },
+  { label: 'Oceania',                value: 'oceania',       emoji: '🌏' }
+];
+
+export const REGION_LANGS = {
+  asia:         ['en','ja','zh','zh-TW','ko','vi'],
+  europe:       ['en','es','fr','de','ru','uk','el'],
+  north_america:['en','es','fr'],
+  south_america:['es','pt-BR'],
+  mea:          ['ar','fa','he','tr','ur'],
+  oceania:      ['en','en-AU','en-NZ']
+};

--- a/bot/index.js
+++ b/bot/index.js
@@ -27,7 +27,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import { randomUUID } from 'crypto';
 import { Redis } from '@upstash/redis';
-import { FLAG_TO_LANG } from './constants.js';
+import { FLAG_TO_LANG, REGIONS, REGION_LANGS } from './constants.js';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -198,14 +198,6 @@ async function handleSetup(interaction) {
     /* ────────── Settings 用 UI ────────── */
 
     /* A) 地域セレクト（後続で言語セレクトへ分岐） */
-    const REGIONS = [
-      { label: 'Asia',                   value: 'asia',          emoji: '🌏' },
-      { label: 'Europe',                 value: 'europe',        emoji: '🌍' },
-      { label: 'North America',          value: 'north_america', emoji: '🌎' },
-      { label: 'South America',          value: 'south_america', emoji: '🌎' },
-      { label: 'Middle East & Africa',   value: 'mea',           emoji: '🌍' },
-      { label: 'Oceania',                value: 'oceania',       emoji: '🌏' }
-    ];
     const rowRegion = new ActionRowBuilder().addComponents(
       new StringSelectMenuBuilder()
         .setCustomId('setting_region')
@@ -292,22 +284,7 @@ async function handleRanking(interaction) {
 }
 
 /* ────────── 6. /help UI (地域→言語) ────────── */
-const HELP_REGIONS = [
-  { label: 'Asia',          value: 'asia',          emoji: '🌏' },
-  { label: 'Europe',        value: 'europe',        emoji: '🌍' },
-  { label: 'North America', value: 'north_america', emoji: '🌎' },
-  { label: 'South America', value: 'south_america', emoji: '🌎' },
-  { label: 'Middle East & Africa', value: 'mea',    emoji: '🌍' },
-  { label: 'Oceania',       value: 'oceania',       emoji: '🌏' }
-];
-const HELP_REGION_LANGS = {
-  asia:         ['en','ja','zh','zh-TW','ko','vi'],
-  europe:       ['en','es','fr','de','ru','uk','el'],
-  north_america:['en','es','fr'],
-  south_america:['es','pt-BR'],
-  mea:          ['ar','fa','he','tr','ur'],
-  oceania:      ['en','en-AU','en-NZ']
-};
+
 
 /* ────────── 7. InteractionCreate 全体 ────────── */
 client.on(Events.InteractionCreate, async (i) => {
@@ -326,7 +303,7 @@ client.on(Events.InteractionCreate, async (i) => {
               .setCustomId('help_region')
               .setPlaceholder('Pick region')
               .addOptions(
-                HELP_REGIONS.map(r => ({ label: r.label, value: r.value, emoji: r.emoji }))
+                REGIONS.map(r => ({ label: r.label, value: r.value, emoji: r.emoji }))
               )
           )
         ],
@@ -338,7 +315,7 @@ client.on(Events.InteractionCreate, async (i) => {
   // --- /help の 地域→言語 フロー ---
   if (i.isStringSelectMenu() && i.customId === 'help_region') {
     const chosenRegion = i.values[0];
-    const langs = HELP_REGION_LANGS[chosenRegion] || ['en'];
+    const langs = REGION_LANGS[chosenRegion] || ['en'];
     return i.update({
       content: '📖 Select a language:',
       components: [
@@ -368,14 +345,6 @@ client.on(Events.InteractionCreate, async (i) => {
   // --- settings: Default Language → 地域選択 → 言語選択 ---
   if (i.isStringSelectMenu() && i.customId === 'setting_region') {
     const chosenRegion = i.values[0];
-    const REGION_LANGS = {
-      asia:         ['en','ja','zh','zh-TW','ko','vi'],
-      europe:       ['en','es','fr','de','ru','uk','el'],
-      north_america:['en','es','fr'],
-      south_america:['es','pt-BR'],
-      mea:          ['ar','fa','he','tr','ur'],
-      oceania:      ['en','en-AU','en-NZ']
-    };
     const langs = REGION_LANGS[chosenRegion] || ['en'];
 
     // ✓: 別メッセージ (Ephemeral) で言語選択を促す


### PR DESCRIPTION
## Summary
- centralize region-language mapping constants in `bot/constants.js`
- use shared constants in `bot/index.js`
- use shared constants in `bot/commands/help.js`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684236b906308320832984d217ea6212