### PR TITLE
Fix bot test script path

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "deploy-commands": "node deploy-commands.js",
     "start": "node index.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules ../node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@upstash/redis": "^1.x.x",


### PR DESCRIPTION
## Summary
- point bot's test script at the workspace root Jest binary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423ba17d188320a5d3550f61ca51c3