### PR TITLE
Update undici to resolve audit warning

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -11,9 +11,13 @@
     "@upstash/redis": "^1.x.x",
     "discord.js": "^14.x.x",
     "dotenv": "^16.x.x",
-    "express": "^4.x.x"
+    "express": "^4.x.x",
+    "undici": "6.21.3"
   },
   "devDependencies": {
     "jest": "^29.7.0"
+  },
+  "overrides": {
+    "undici": "6.21.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,23 @@
 {
-  "name": "global-chat-bot",
-  "version": "1.0.0",
+  "name": "global-chat-root",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "global-chat-root",
+      "workspaces": [
+        "bot"
+      ]
+    },
+    "bot": {
       "name": "global-chat-bot",
       "version": "1.0.0",
       "dependencies": {
         "@upstash/redis": "^1.x.x",
         "discord.js": "^14.x.x",
         "dotenv": "^16.x.x",
-        "express": "^4.x.x"
+        "express": "^4.x.x",
+        "undici": "6.21.3"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -647,6 +653,15 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@discordjs/util": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
@@ -1209,9 +1224,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1251,12 +1266,12 @@
       "license": "MIT"
     },
     "node_modules/@upstash/redis": {
-      "version": "1.34.9",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.9.tgz",
-      "integrity": "sha512-7qzzF2FQP5VxR2YUNjemWs+hl/8VzJJ6fOkT7O7kt9Ct8olEVzb1g6/ik6B8Pb8W7ZmYv81SdlVV9F6O8bh/gw==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.0.tgz",
+      "integrity": "sha512-WUm0Jz1xN4DBDGeJIi2Y0kVsolWRB2tsVds4SExaiLg4wBdHFMB+8IfZtBWr+BP0FvhuBr5G1/VLrJ9xzIWHsg==",
       "license": "MIT",
       "dependencies": {
-        "crypto-js": "^4.2.0"
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -1844,12 +1859,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1924,9 +1933,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.8",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.8.tgz",
-      "integrity": "sha512-xuRXPD44FcbKHrQK15FS1HFlMRNJtsaZou/SVws18vQ7zHqmlxyDktMkZpyvD6gE2ctGOVYC/jUyoMMAyBWfcw==",
+      "version": "0.38.11",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.11.tgz",
+      "integrity": "sha512-XN0qhcQpetkyb/49hcDHuoeUPsQqOkb17wbV/t48gUkoEDi4ajhsxqugGcxvcN17BBtI9FPPWEgzv6IhQmCwyw==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
@@ -1957,6 +1966,15 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/dotenv": {
@@ -2430,6 +2448,10 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/global-chat-bot": {
+      "resolved": "bot",
+      "link": true
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -4566,10 +4588,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "6.21.3",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "name": "global-chat-root",
   "private": true,
-  "workspaces": ["bot"],
+  "workspaces": [
+    "bot"
+  ],
   "scripts": {
     "test": "npm --workspace bot test"
+  },
+  "overrides": {
+    "undici": "6.21.3"
   }
 }


### PR DESCRIPTION
## Summary
- run `npm audit fix` and update the undici dependency
- regenerate lockfiles so all packages use undici 6.21.3

## Testing
- `npm audit --json | jq '.metadata.vulnerabilities'`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423e6d4b74832080200325ec8588c6