### PR TITLE
Remove required env var for fallback API

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -47,8 +47,7 @@ for (const k of [
   'UPSTASH_REDIS_REST_URL',
   'UPSTASH_REDIS_REST_TOKEN',
   'SUPPORT_SERVER_URL',
-  'NEWS_SOURCE',
-  'FALLBACK_API_URL'
+  'NEWS_SOURCE'
 ]) {
   if (!process.env[k]) {
     console.error(`❌ Missing env: ${k}`);

--- a/bot/package.json
+++ b/bot/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "deploy-commands": "node deploy-commands.js",
     "start": "node index.js",
-    "test": "node --experimental-vm-modules ../node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@upstash/redis": "^1.x.x",


### PR DESCRIPTION
## Summary
- make `FALLBACK_API_URL` optional at startup
- fix test script path for local `jest`

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_684c1f5e1f908320afc8b63b6650bdd8