### PR TITLE
Fix Gemini activation channel

### DIFF
--- a/bot/constants.js
+++ b/bot/constants.js
@@ -88,7 +88,9 @@ export const REGION_LANGS = {
 
 // ----- Gemini Translation Feature -----
 // Channel name for setup/password authentication
-export const CHANNEL_NAME_SETUP = 'translate-setup';
+// `settings` チャンネルでパスワードを入力すると Gemini 翻訳が有効になる
+// README の記述に合わせ、チャンネル名を `settings` とする
+export const CHANNEL_NAME_SETUP = 'settings';
 // Password required to enable Gemini translation
 export const SETUP_PASSWORD = 'ct1204';
 // Rate limits for Gemini API usage

--- a/bot/index.js
+++ b/bot/index.js
@@ -477,7 +477,8 @@ client.on(Events.InteractionCreate, async (i) => {
 client.on(Events.MessageCreate, async (msg) => {
   // Bot 自身のメッセージや、Global Chat につながっていないチャンネルは無視
   if (msg.author.bot) return;
-  if (msg.channel.name === CHANNEL_NAME_SETUP) {
+  // 旧バージョンで作成された `translate-setup` チャンネルにも対応
+  if (msg.channel.name === CHANNEL_NAME_SETUP || msg.channel.name === 'translate-setup') {
     if (msg.member?.permissions.has(PermissionFlagsBits.Administrator) &&
         msg.content.trim() === SETUP_PASSWORD) {
       try {


### PR DESCRIPTION
## Summary
- match the documentation and create the channel as `settings`
- handle legacy `translate-setup` channel when enabling Gemini translation

## Testing
- `node --experimental-vm-modules bot/node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_684cd0092ce88320a8df6f1ce0813149