### PR TITLE
Update setup category name

### DIFF
--- a/bot/commands/setup.js
+++ b/bot/commands/setup.js
@@ -4,7 +4,7 @@ export default {
   data: new SlashCommandBuilder()
     .setName('setup')
     .setDescription(
-      'Create the “Global Chat” category, channels, and register this server to the hub.'
+      'Create the “Global-Chat Settings” category, channels, and register this server to the hub.'
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator) // Admin-only
 };

--- a/bot/index.js
+++ b/bot/index.js
@@ -233,9 +233,9 @@ async function handleSetup(interaction) {
       return interaction.editReply('❌ Need Administrator permission.');
     }
 
-    /* (2) “Global Chat” カテゴリ */
+    /* (2) “Global-Chat Settings” カテゴリ */
     const category = await interaction.guild.channels.create({
-      name: 'Global Chat',
+      name: 'Global-Chat Settings',
       type: ChannelType.GuildCategory
     });
 


### PR DESCRIPTION
## Summary
- adjust category creation to use the name "Global-Chat Settings"
- update setup command description accordingly

## Testing
- `npm --workspace bot test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d06e1685c8320abf9a9a12db8edd0