### PR TITLE
Implement setup guard

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -233,6 +233,14 @@ async function handleSetup(interaction) {
       return interaction.editReply('❌ Need Administrator permission.');
     }
 
+    // Guard: prevent duplicate setup by checking existing category
+    const existingCategory = interaction.guild.channels.cache.find(
+      c => c.type === ChannelType.GuildCategory && c.name === 'Global-Chat Settings'
+    );
+    if (existingCategory) {
+      return interaction.editReply('⚠️ Setup has already been run.');
+    }
+
     /* (2) “Global Chat” カテゴリ */
     const category = await interaction.guild.channels.create({
       name: 'Global Chat',


### PR DESCRIPTION
## Summary
- avoid duplicate `/setup` by checking for existing `Global-Chat Settings` category

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_684d06e3c7988320838c54edeaa41421