### PR TITLE
Use Google GenAI for translations

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -11,7 +11,8 @@
     "@upstash/redis": "^1.x.x",
     "discord.js": "^14.x.x",
     "dotenv": "^16.x.x",
-    "express": "^4.x.x"
+    "express": "^4.x.x",
+    "@google/genai": "^1.5.1"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
## Summary
- add `@google/genai` dependency
- migrate Gemini translation to Google GenAI SDK with timeout
- notify users when Gemini API errors occur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d06e9199c832085d216cb32f78281