### PR TITLE
Update setup to post instructions in settings

### DIFF
--- a/bot/commands/setup.js
+++ b/bot/commands/setup.js
@@ -4,7 +4,7 @@ export default {
   data: new SlashCommandBuilder()
     .setName('setup')
     .setDescription(
-      'Create the “Global-Chat Settings” category, channels, and register this server to the hub.'
+      'Create the “Global Chat” category, channels, and register this server to the hub.'
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator) // Admin-only
 };

--- a/bot/index.js
+++ b/bot/index.js
@@ -294,9 +294,9 @@ async function handleSetup(interaction) {
       return interaction.editReply('❌ Need Administrator permission.');
     }
 
-    /* (2) “Global-Chat Settings” カテゴリ */
+    /* (2) “Global Chat” カテゴリ */
     const category = await interaction.guild.channels.create({
-      name: 'Global-Chat Settings',
+      name: 'Global Chat',
       type: ChannelType.GuildCategory
     });
 
@@ -386,16 +386,15 @@ async function handleSetup(interaction) {
       new ButtonBuilder().setURL(process.env.SUPPORT_SERVER_URL).setLabel('Support').setStyle(ButtonStyle.Link)
     );
 
-    /* E) send settings UI to the admin (ephemeral) */
-    await interaction.followUp({
+    /* E) settings チャンネルへ送信 */
+    await settings.send({
       content:
         '**Global Chat Settings**\n\n' +
         '1️⃣ Default Language (select region → bot asks language)\n' +
         '2️⃣ Timezone\n' +
         '3️⃣ Auto-Translate ON / OFF\n' +
         '4️⃣ Detect Timezone (based on your Discord locale)\n',
-      components: [rowRegion, rowTZ, rowAuto, rowMisc],
-      ephemeral: true
+      components: [rowRegion, rowTZ, rowAuto, rowMisc]
     });
 
     // Gemini translation setup


### PR DESCRIPTION
## Summary
- fix `/setup` description
- create **Global Chat** category instead of Global-Chat Settings
- post the language & timezone setup UI directly in the settings channel

## Testing
- `npm test --prefix bot`

------
https://chatgpt.com/codex/tasks/task_e_684d22062e748320b680b0b63e9872ce